### PR TITLE
allow level up if > required XP

### DIFF
--- a/site/hero/hero.php
+++ b/site/hero/hero.php
@@ -169,7 +169,7 @@ class Hero
 	function levelUP()
 	{
 		//returns true if it worked
-		if($this->CurrentXP == $this->LevelUpXP)//we have enough XP
+		if($this->CurrentXP >= $this->LevelUpXP)//we have enough XP
 		{
 			$this->forceLevelUP();
 			return true;


### PR DESCRIPTION
not sure why, but we had a few characters who had more than required XP
